### PR TITLE
fix: increase disk space

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,5 +3,5 @@ applications:
 - buildpacks:
     - python_buildpack
   memory: 256M
-  disk_quota: 256M
+  disk_quota: 512M
   health-check-type: process


### PR DESCRIPTION
Either the recent Python version bump or gevent took the disk space needed over what was being allocated